### PR TITLE
parallelized MakeDb.py

### DIFF
--- a/bin/MakeDb.py
+++ b/bin/MakeDb.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/home/rdb9/.conda/envs/changeo/bin/python
 """
 Create tab-delimited database file to store sequence alignment information
 """
@@ -1098,15 +1098,28 @@ if __name__ == "__main__":
     if 'command' in args_dict: del args_dict['command']
     if 'func' in args_dict: del args_dict['func']
 
-    # Call main
+
+    ds=[]
+
+    # initialize a dict for each execution, and add to list
     for i, f in enumerate(args.__dict__['aligner_files']):
-        args_dict['aligner_file'] = f
-        args_dict['out_file'] = args.__dict__['out_files'][i] \
+        tmp_dict=args_dict.copy()
+        tmp_dict['aligner_file'] = f
+        tmp_dict['out_file'] = args.__dict__['out_files'][i] \
                                 if args.__dict__['out_files'] else None
         if 'seq_files' in args.__dict__:
-            args_dict['seq_file'] = args.__dict__['seq_files'][i] \
+            tmp_dict['seq_file'] = args.__dict__['seq_files'][i] \
                                     if args.__dict__['seq_files'] else None
         if 'cellranger_files' in args.__dict__:
-            args_dict['cellranger_file'] = args.__dict__['cellranger_files'][i] \
+            tmp_dict['cellranger_file'] = args.__dict__['cellranger_files'][i] \
                                            if args.__dict__['cellranger_files'] else None
-        args.func(**args_dict)
+        ds.append(tmp_dict)
+
+    # now do the loop in parallel
+    from concurrent.futures import ProcessPoolExecutor
+
+    with ProcessPoolExecutor() as executor:
+        futures = [executor.submit(args.func, **d) for d in ds]
+        result = [f.result() for f in futures]
+        # original code threw away return values, so I am too...
+                       


### PR DESCRIPTION
I parallelized the main for loop in MakeDb.py, using concurrent.futures.ProcessPoolExecutor.  Each input set should be computed in parallel, up to the number of cpus.  The code should automatically detect the number of cpus and limit the parallelism to that.