### PR TITLE
Add -f/-u arguments to ParseDb merge

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -1,6 +1,15 @@
 Release Notes
 ===============================================================================
 
+Version 1.3.6dev:  Unreleased
+-------------------------------------------------------------------------------
+
+ParseDb:
+
++ ``ParseDb.py merge`` now accepts ``-f`` and ``-u`` arguments to annotate
+  merged records with a sample identifier field, with one value per input
+  file specified via ``-d``.
+
 Version 1.3.5:  April 14, 2026
 -------------------------------------------------------------------------------
 
@@ -18,10 +27,10 @@ MakeDb:
 
 Gene:
 
-+ Added support for dual-locus ``TRA/TRD`` gene detection. ``getLocus`` now 
-  correctly identifies genes with the ``TRAV.../DV...`` naming convention 
++ Added support for dual-locus ``TRA/TRD`` gene detection. ``getLocus`` now
+  correctly identifies genes with the ``TRAV.../DV...`` naming convention
   (e.g., ``TRAV14/DV4``) and returns ``TRA/TRD`` as the locus.
-+ Fixed a bug where ``getLocus`` would raise a ``TypeError`` when the gene 
++ Fixed a bug where ``getLocus`` would raise a ``TypeError`` when the gene
   call was ``None``.
 
 

--- a/bin/ParseDb.py
+++ b/bin/ParseDb.py
@@ -796,13 +796,18 @@ def updateDbFile(db_file, field, values, updates, out_file=None, out_args=defaul
     return pass_handle.name
 
 
-def mergeDbFiles(db_files, drop=False, out_file=None, out_args=default_out_args):
+def mergeDbFiles(db_files, drop=False, field=None, values=None,
+                  out_file=None, out_args=default_out_args):
     """
     Updates field and value pairs to a database file
 
     Arguments:
       db_files : list of database file names.
       drop : if True drop columns not present in all files.
+      field : name of the field to add annotating the source file of each record;
+              if None do not add a sample identifier field.
+      values : list of sample identifiers, one per file in db_files, assigned to
+               field for each record; ignored if field is None.
       out_file : output file name. Automatically generated from the input file if None.
       out_args : common output argument dictionary from parseCommonArgs.
 
@@ -814,6 +819,9 @@ def mergeDbFiles(db_files, drop=False, out_file=None, out_args=default_out_args)
     log['COMMAND'] = 'merge'
     log['FILES'] = ','.join([os.path.basename(f) for f in db_files])
     log['DROP'] = drop
+    if field is not None:
+        log['FIELD'] = field
+        log['VALUES'] = ','.join(values)
     printLog(log)
 
     # Open input
@@ -829,6 +837,8 @@ def mergeDbFiles(db_files, drop=False, out_file=None, out_args=default_out_args)
         field_set = set.union(*map(set, field_list))
     field_order = OrderedDict([(f, None) for f in chain(*field_list)])
     out_fields = [f for f in field_order if f in field_set]
+    if field is not None and field not in out_fields:
+        out_fields.append(field)
 
     # Open output file
     if out_file is not None:
@@ -842,11 +852,15 @@ def mergeDbFiles(db_files, drop=False, out_file=None, out_args=default_out_args)
     # Iterate over records
     start_time = time()
     rec_count = 0
-    for db in db_iters:
+    for i, db in enumerate(db_iters):
         for rec in db:
             # Print progress for previous iteration
             printProgress(rec_count, result_count, 0.05, start_time=start_time)
             rec_count += 1
+
+            # Annotate sample identifier
+            if field is not None:
+                rec[field] = values[i]
 
             # Write records
             pass_writer.writeDict(rec)
@@ -1036,6 +1050,14 @@ def getArgParser():
                               help='''If specified, drop fields that do not exist in all input files.
                                    Otherwise, include all columns in all files and fill missing data
                                    with empty strings.''')
+    group_merge.add_argument('-f', action='store', dest='field', default=None,
+                              help='''Name of the field to add to the output file annotating each
+                                   record with a sample identifier. If not specified, no sample
+                                   identifier field is added.''')
+    group_merge.add_argument('-u', nargs='+', action='store', dest='values', default=None,
+                              help='''Sample identifiers to assign to the field specified by -f, one
+                                   per input file (-d) and in the same order. Ignored if -f is not
+                                   specified.''')
     parser_merge.set_defaults(func=mergeDbFiles)
 
     # Subparser to partition files by annotation values
@@ -1078,6 +1100,11 @@ if __name__ == '__main__':
         parser.error('You must specify exactly one new name (-k) per field (-f)')
     elif args.command == 'update' and len(args_dict['values']) != len(args_dict['updates']):
         parser.error('You must specify exactly one value (-u) per replacement (-t)')
+    elif args.command == 'merge' and args_dict['field'] is not None:
+        if args_dict['values'] is None:
+            parser.error('You must specify sample identifiers (-u) when using -f')
+        elif len(args_dict['values']) != len(args_dict['db_files']):
+            parser.error('You must specify exactly one sample identifier (-u) per input file (-d)')
 
     # Call parser function for each database file
     if args.command == 'merge':

--- a/tests/test_ParseDb.py
+++ b/tests/test_ParseDb.py
@@ -7,8 +7,11 @@ __author__ = 'Jason Anthony Vander Heiden'
 from changeo import __version__, __date__
 
 # Imports
+import csv
 import os
+import shutil
 import sys
+import tempfile
 import time
 import unittest
 
@@ -25,10 +28,44 @@ class Test_ParseDb(unittest.TestCase):
     def setUp(self):
         print('-> %s()' % self._testMethodName)
         self.start = time.time()
+        self.tmp_dir = tempfile.mkdtemp()
 
     def tearDown(self):
+        shutil.rmtree(self.tmp_dir)
         t = time.time() - self.start
         print("<- %s() %.3f" % (self._testMethodName, t))
+
+    def _write_tsv(self, name, rows):
+        path = os.path.join(self.tmp_dir, name)
+        with open(path, 'w', newline='') as f:
+            writer = csv.DictWriter(f, fieldnames=list(rows[0].keys()), delimiter='\t')
+            writer.writeheader()
+            writer.writerows(rows)
+        return path
+
+    def _read_tsv(self, path):
+        with open(path, 'r', newline='') as f:
+            return list(csv.DictReader(f, delimiter='\t'))
+
+    # @unittest.skip("-> mergeDbFiles() skipped\n")
+    def test_mergeDbFiles(self):
+        file1 = self._write_tsv('sample1.tsv', [{'SEQUENCE_ID': 'A1', 'V_CALL': 'IGHV1'},
+                                                 {'SEQUENCE_ID': 'A2', 'V_CALL': 'IGHV2'}])
+        file2 = self._write_tsv('sample2.tsv', [{'SEQUENCE_ID': 'B1', 'V_CALL': 'IGHV3'}])
+        out_file = os.path.join(self.tmp_dir, 'merged.tsv')
+
+        # Merge without sample annotation
+        ParseDb.mergeDbFiles([file1, file2], out_file=out_file)
+        records = self._read_tsv(out_file)
+        self.assertEqual(len(records), 3)
+        self.assertNotIn('SAMPLE', records[0])
+
+        # Merge with sample annotation
+        ParseDb.mergeDbFiles([file1, file2], field='SAMPLE', values=['sample1', 'sample2'],
+                              out_file=out_file)
+        records = self._read_tsv(out_file)
+        results = {r['SEQUENCE_ID']: r['SAMPLE'] for r in records}
+        self.assertDictEqual(results, {'A1': 'sample1', 'A2': 'sample1', 'B1': 'sample2'})
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Adds -f/-u arguments to the merge subcommand, allowing merged records to be annotated with a per-input-file sample identifier field.

Fixes #167